### PR TITLE
test: remove codacy from static checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Tasktix_Tasktix&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Tasktix_Tasktix)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=Tasktix_Tasktix&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=Tasktix_Tasktix)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/f5589385fcd14310bc4f766cba51593c)](https://app.codacy.com/gh/Tasktix/Tasktix/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![DeepSource](https://app.deepsource.com/gh/Tasktix/Tasktix.svg/?label=active+issues&show_trend=true&token=htsvS3wjjtryq3kgw4BYXNYa)](https://app.deepsource.com/gh/Tasktix/Tasktix/)
 
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Tasktix_Tasktix&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=Tasktix_Tasktix)


### PR DESCRIPTION
Codacy is extremely noisy and hasn't contributed any significant issue identification/correction because it mostly relies on other tools that are in use, such as ESLint and Semgrep, that have more sane defaults than what Codacy picked. Using it increases developer burden without producing results, so it is being removed. The only impact to the repo contents is removing its badge from the README.