### PR TITLE
fix: resolve SonarQube security complaint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,15 +2,14 @@ name: Lint
 
 on: [pull_request]
 
-permissions:
-  contents: read
-  pull-requests: write
-  statuses: write
-
 jobs:
   lint:
     name: ESLint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Fixes potential security gaps in CI jobs. Should restore the project's security rating to an "A"

## Reviewer Notes

From SonarQube on why this is important:

> Granting read permissions at the workflow level applies those permissions to all jobs in the workflow by default. This violates the principle of least privilege, as jobs that don’t require these read permissions will still inherit them unnecessarily.
>
> ### What is the potential impact?
> 
> When read permissions are granted at the workflow level, all jobs inherit these permissions regardless of whether they need them. This creates several security risks:
> 
> ### Unauthorized reconnaissance
> 
> Jobs with unnecessary `pull-requests: read` or `issues: read` permissions could be exploited to gather sensitive information from pull request discussions, issue comments, or code review feedback. This information could reveal security vulnerabilities, internal processes, or other sensitive details that could be used for targeted attacks.
> 
> ### Security event exposure
> 
> Jobs that inherit `security-events: read` permissions could access security vulnerability data, dependency information, or other security-related metadata. While this information may seem less critical than write access, it could still be used by attackers to identify vulnerable components or plan targeted attacks based on known security issues.