### PR TITLE
fix: build from correct Dockerfile for deploy image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,3 +79,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-deploy.outputs.tags }}
+          file: Dockerfile.deploy


### PR DESCRIPTION
The `tasktix-deploy` image has been building with the normal Dockerfile instead of the one for the deploy image. This PR fixes that so the correct image is pushed to `ghcr.io/tasktix/tasktix-deploy:latest`.
