### PR TITLE
fix: member permission updates rejected by database

### DIFF
--- a/lib/database/list.ts
+++ b/lib/database/list.ts
@@ -320,7 +320,8 @@ export async function updateListMember(
         // full transaction duration
         await tx.$queryRaw`
           SELECT \`userId\` FROM \`ListMember\`
-          WHERE \`listId\` = ${listId} AND \`name\` = 'Admin'
+            INNER JOIN \`MemberRole\` ON \`ListMember\`.\`roleId\` = \`MemberRole\`.\`id\`
+          WHERE \`ListMember\`.\`listId\` = ${listId} AND \`MemberRole\`.\`name\` = 'Admin'
           FOR UPDATE;
         `;
 
@@ -337,7 +338,9 @@ export async function updateListMember(
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted }
     );
-  } catch {
+  } catch (error) {
+    console.log(error);
+
     return false;
   }
 


### PR DESCRIPTION
Fixes a bug preventing list members' roles from being changed.

## Related Issues
- Closes #122 

## Testing Coverage

This bug is only detectable via end-to-end tests. This behavior should be verified when those test suites are added.