### PR TITLE
fix: better-auth session update conflict

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -2,16 +2,18 @@ FROM node:lts-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
+COPY tsconfig.json prisma.config.ts ./
+COPY prisma ./prisma
+
+RUN npm ci --ignore-scripts && npm run prisma:generate
 
 # Stub import of server-only, this interprets test environment as client component
 # server-only still prevents server code being run on client in development/production
 RUN echo "" > "/app/node_modules/server-only/index.js"
 
 COPY scripts/test_service_entry.sh ./entry.sh
-COPY tsconfig.json prisma.config.ts ./
-COPY prisma ./prisma
 COPY lib/auth.ts ./lib/auth.ts
+COPY lib/database/db_connect.ts ./lib/database/db_connect.ts
 COPY lib/model/color.ts ./lib/model/color.ts
 
 CMD [ "sh", "entry.sh" ]

--- a/app/page.test.ts
+++ b/app/page.test.ts
@@ -19,25 +19,20 @@
 import { redirect } from 'next/navigation';
 
 import Home from '@/app/page';
-import { getUser } from '@/lib/session';
 import User from '@/lib/model/user';
+import { useAuth } from '@/components/AuthProvider';
 
-vi.mock('next/navigation', () => ({
-  redirect: vi.fn()
-}));
-
-vi.mock('@/lib/session', () => ({
-  getUser: vi.fn()
-}));
+vi.mock('next/navigation');
+vi.mock('@/components/AuthProvider');
 
 describe('root route redirect logic', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('redirects authenticated users to /list', async () => {
-    vi.mocked(getUser).mockResolvedValue(
-      new User(
+  it('redirects authenticated users to /list', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      loggedInUser: new User(
         'userId',
         'testUser',
         'test@example.com',
@@ -46,17 +41,19 @@ describe('root route redirect logic', () => {
         new Date(),
         {}
       )
-    );
+    } as ReturnType<typeof useAuth>);
 
-    await Home();
+    Home();
 
     expect(redirect).toHaveBeenCalledWith('/list');
   });
 
-  it('redirects unauthenticated users to /about', async () => {
-    vi.mocked(getUser).mockResolvedValue(false);
+  it('redirects unauthenticated users to /about', () => {
+    vi.mocked(useAuth).mockReturnValue({ loggedInUser: false } as ReturnType<
+      typeof useAuth
+    >);
 
-    await Home();
+    Home();
 
     expect(redirect).toHaveBeenCalledWith('/about');
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+'use client';
+
 import { redirect } from 'next/navigation';
 
 import { useAuth } from '@/components/AuthProvider';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,8 +17,6 @@
  *
  */
 
-'use server';
-
 import { redirect } from 'next/navigation';
 
 import { useAuth } from '@/components/AuthProvider';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,9 +17,11 @@
  *
  */
 
+'use server';
+
 import { redirect } from 'next/navigation';
 
-import { getUser } from '@/lib/session';
+import { useAuth } from '@/components/AuthProvider';
 
 /* Root route handler.
  *
@@ -30,12 +32,9 @@ import { getUser } from '@/lib/session';
  *
  * No UI is rendered here.
  */
-export default async function Home() {
-  const user = await getUser();
+export default function Home() {
+  const { loggedInUser } = useAuth();
 
-  if (user) {
-    redirect('/list');
-  }
-
-  redirect('/about');
+  if (loggedInUser) redirect('/list');
+  else redirect('/about');
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { getUser } from '@/lib/session';
+import { useAuth } from '@/components/AuthProvider';
 
 import UserProperties from './components/UserProperties';
 
@@ -24,14 +24,14 @@ import UserProperties from './components/UserProperties';
  * Gets current user information and sends it to UserProperties
  *
  */
-export default async function Page() {
-  const userDetails = await getUser();
+export default function Page() {
+  const { loggedInUser } = useAuth();
 
   return (
     <main className='flex p-6 justify-center flex-grow'>
       <div className='border-2 border-content3 bg-content1 shadow-lg shadow-content2 w-130 m-4 rounded-lg px-4 h-full'>
         <h1 className='text-2xl p-4'>Profile</h1>
-        <UserProperties user={JSON.stringify(userDetails)} />
+        <UserProperties user={JSON.stringify(loggedInUser)} />
       </div>
     </main>
   );

--- a/components/AuthProvider/index.tsx
+++ b/components/AuthProvider/index.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export { default } from './AuthProvider';
+'use client';
 
+export { default } from './AuthProvider';
 export { useAuth } from './authHook';

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,12 +22,10 @@ import 'server-only';
 
 import { betterAuth, DBFieldType } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { PrismaClient } from '@prisma/client';
 import { genericOAuth, haveIBeenPwned, username } from 'better-auth/plugins';
 
 import { namedColors } from './model/color';
-
-const prisma = new PrismaClient();
+import { prisma } from './database/db_connect';
 
 export type OAuthConfig = {
   githubEnabled: boolean;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,11 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { PrismaClient } from '@prisma/client';
-
 import { auth } from '@/lib/auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/database/db_connect';
 
 async function main() {
   await auth.api.signUpEmail({


### PR DESCRIPTION
> [!IMPORTANT]
> 
> Likely changing approach; see https://github.com/Tasktix/Tasktix/issues/121#issuecomment-4065842778. This would be good for allowing the homepage's `redirect` to happen server-side instead of relying on client-side redirects that seem to occasionally fail as well.

When loading the Tasktix homepage, users are intermittently met with a message that a server-side error occurred. This (hopefully) resolves that issue.

## Related Issues

- Closes #121 

## Changes

- [x] Removed duplicate Prisma client instantiation
- [x] Changed `getUser` calls to `useAuth` where possible

## Testing Coverage

This bug seems to be triggered by a lost race condition, so I have been unsuccessful in consistently reproducing this error. While I have never encountered it with these fixes, we will need to monitor logs in prod to ensure the issue is truly resolved.

## Reviewer Notes

The error message for this bug is not very helpful, especially since it doesn't contain a stack trace. My guess is that the cause is BetterAuth regenerating a session user's session multiple times simultaneously, which causes a race condition. If one session regeneration starts before the other but finishes after, this causes the error to be thrown.

I made 2 attempts to resolve this:
- BetterAuth had a separate Prisma client than the rest of the app. This hopefully isn't the root cause (or horizontal scaling will be impossible), but is worth fixing.
- This error has only been encountered on the homepage. `app/layout.tsx` makes one call to `getUser` and `app/page.tsx` makes a second, which could be the race condition trigger. `app/page.tsx` has been updated to use the Context object provided by `app/layout.tsx` instead of fetching the user directly to attempt to resolve this.