### PR TITLE
fix: retry session get/refresh when error thrown

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts --omit dev
 
 # Stub import of server-only, this interprets test environment as client component
 # server-only still prevents server code being run on client in development/production
@@ -12,6 +12,7 @@ COPY scripts/test_service_entry.sh ./entry.sh
 COPY tsconfig.json prisma.config.ts ./
 COPY prisma ./prisma
 COPY lib/auth.ts ./lib/auth.ts
+COPY lib/database/db_connect.ts ./lib/database/db_connect.ts
 COPY lib/model/color.ts ./lib/model/color.ts
 
 CMD [ "sh", "entry.sh" ]

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { getUser } from '@/lib/session';
+'use client';
+
+import { useAuth } from '@/components/AuthProvider';
 
 import UserProperties from './components/UserProperties';
 
@@ -24,14 +26,14 @@ import UserProperties from './components/UserProperties';
  * Gets current user information and sends it to UserProperties
  *
  */
-export default async function Page() {
-  const userDetails = await getUser();
+export default function Page() {
+  const { loggedInUser } = useAuth();
 
   return (
-    <main className='flex p-6 justify-center flex-grow'>
+    <main className='flex p-6 justify-center grow'>
       <div className='border-2 border-content3 bg-content1 shadow-lg shadow-content2 w-130 m-4 rounded-lg px-4 h-full'>
         <h1 className='text-2xl p-4'>Profile</h1>
-        <UserProperties user={JSON.stringify(userDetails)} />
+        <UserProperties user={JSON.stringify(loggedInUser)} />
       </div>
     </main>
   );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -27,6 +27,8 @@ import UserProperties from './components/UserProperties';
  *
  */
 export default function Page() {
+  // Nothing substantial to test here - skipcq: TCV-001
+
   const { loggedInUser } = useAuth();
 
   return (

--- a/lib/__tests__/util.test.ts
+++ b/lib/__tests__/util.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tasktix: A powerful and flexible task-tracking tool for all.
+ * Copyright (C) 2025 Nate Baird & other Tasktix contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { retry } from '../util';
+
+describe('retry', () => {
+  test('It runs the function only once and returns its value if it succeeds', () => {
+    const fn = vi.fn().mockReturnValue(true);
+
+    const result = retry(fn) as true | undefined;
+
+    expect(result).toBe(true);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  test('It retries the function and returns its value if it fails the first time', () => {
+    const fn = vi.fn().mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    fn.mockReturnValueOnce(true);
+
+    const result = retry(fn) as true | undefined;
+
+    expect(result).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('It retries the function 3 times by default and returns undefined if still fails', () => {
+    const fn = vi.fn().mockImplementation(() => {
+      throw new Error();
+    });
+
+    const result = retry(fn) as true | undefined;
+
+    expect(result).toBe(undefined);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test('It retries the function as many times as specified and returns undefined if still fails', () => {
+    const fn = vi.fn().mockImplementation(() => {
+      throw new Error();
+    });
+
+    const result = retry(fn, 6) as true | undefined;
+
+    expect(result).toBe(undefined);
+    expect(fn).toHaveBeenCalledTimes(6);
+  });
+});

--- a/lib/__tests__/util.test.ts
+++ b/lib/__tests__/util.test.ts
@@ -48,7 +48,7 @@ describe('retry', () => {
 
     const result = retry(fn) as true | undefined;
 
-    expect(result).toBe(undefined);
+    expect(result).toBe(undefined); // toBe expects an argument- skipcq: JS-W1042
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
@@ -59,7 +59,7 @@ describe('retry', () => {
 
     const result = retry(fn, 6) as true | undefined;
 
-    expect(result).toBe(undefined);
+    expect(result).toBe(undefined); // toBe expects an argument- skipcq: JS-W1042
     expect(fn).toHaveBeenCalledTimes(6);
   });
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,12 +22,10 @@ import 'server-only';
 
 import { betterAuth, DBFieldType } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { PrismaClient } from '@prisma/client';
 import { genericOAuth, haveIBeenPwned, username } from 'better-auth/plugins';
 
 import { namedColors } from './model/color';
-
-const prisma = new PrismaClient();
+import { prisma } from './database/db_connect';
 
 export type OAuthConfig = {
   githubEnabled: boolean;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -16,24 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-'use server';
-
-import { headers } from 'next/headers';
-
-import { getUserById } from '@/lib/database/user';
-import User from '@/lib/model/user';
-
-import { auth } from './auth';
-import { retry } from './util';
-
-export async function getUser(): Promise<User | false> {
-  const session = await retry(
-    async () => await auth.api.getSession({ headers: await headers() })
-  );
-
-  if (!session) return false;
-
-  const user = await getUserById(session.user.id);
-
-  return user;
+export function retry<T>(fn: () => T, attempts: number = 3): T | void {
+  for (let i = 1; i <= attempts; i++)
+    try {
+      return fn();
+    } catch {}
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -31,5 +31,5 @@ export function retry<T>(fn: () => T, attempts = 3): T | undefined {
       /* Don't need to do anything; already retrying in loop */
     }
 
-  return;
+  return undefined;
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -16,9 +16,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export function retry<T>(fn: () => T, attempts: number = 3): T | void {
+/**
+ * Catches any errors thrown by the given function and retries it to resolve ephemeral
+ * errors
+ *
+ * @param fn The function to retry
+ * @param attempts The maximum number of times to retry the function
+ */
+export function retry<T>(fn: () => T, attempts = 3): T | undefined {
   for (let i = 1; i <= attempts; i++)
     try {
       return fn();
-    } catch {}
+    } catch {
+      /* Don't need to do anything; already retrying in loop */
+    }
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -30,4 +30,6 @@ export function retry<T>(fn: () => T, attempts = 3): T | undefined {
     } catch {
       /* Don't need to do anything; already retrying in loop */
     }
+
+  return;
 }


### PR DESCRIPTION
When loading the Tasktix homepage, users are intermittently met with a message that a server-side error occurred. This (hopefully) resolves that issue.

## Related Issues

- Closes #121 

## Changes

- [x] Removed duplicate Prisma client instantiation
- [x] Added retry and error catching to avoid graceless failure when `auth.api.getSession` fails
- [x] Decreased database calls by using the `useAuth` hook over `getUser` where possible

## Testing Coverage

This bug seems to be triggered by a lost race condition, so I have been unsuccessful in consistently reproducing this error. While I have never encountered it with these fixes, we will need to monitor logs in prod to ensure the issue is truly resolved.

## Reviewer Notes

The error message for this bug is not very helpful, especially since it doesn't contain a stack trace. My guess is that the cause is BetterAuth regenerating a session user's session multiple times simultaneously, which causes a race condition. If one session regeneration starts before the other but finishes after, this causes the error to be thrown.

I made 2 attempts to resolve this:

- BetterAuth had a separate Prisma client than the rest of the app. This hopefully isn't the root cause (or horizontal scaling will be impossible), but is worth fixing.
- If the `auth.api.getSession` transaction is aborted, it throws an error. I added catch & retry logic to try to resolve this.

All errors are now caught, too, so the user-facing error message is styled better (not a white screen that says "Application error") if this fails to fully resolve the race condition.