### PR TITLE
feat: add backend to support section change 

### DIFF
--- a/app/api/item/[id]/route.test.ts
+++ b/app/api/item/[id]/route.test.ts
@@ -19,13 +19,15 @@
 import {
   deleteListItem,
   getListItemById,
-  updateListItem
+  updateListItem,
+  updateItemSection
 } from '@/lib/database/listItem';
 import { getRoleByItem } from '@/lib/database/user';
 import ListItem from '@/lib/model/listItem';
 import MemberRole from '@/lib/model/memberRole';
 import User from '@/lib/model/user';
 import { getUser } from '@/lib/session';
+import { querySectionInList } from '@/lib/database/list';
 
 import { DELETE, PATCH } from './route';
 
@@ -43,6 +45,7 @@ const ITEM_PATH = `http://localhost/api/item/${MOCK_ITEM.id}` as const;
 
 vi.mock('@/lib/session');
 vi.mock('@/lib/database/listItem');
+vi.mock('@/lib/database/list');
 vi.mock('@/lib/database/user');
 
 beforeEach(() => {
@@ -76,6 +79,37 @@ describe('PATCH', () => {
     expect(response.status).toBe(200);
     expect(updateListItem).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ name: 'New item name' })
+    );
+  });
+
+  test('Changes Item section when valid section provided and requestor is permissioned', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER);
+    vi.mocked(getListItemById).mockResolvedValue({
+      ...MOCK_ITEM,
+      listId: 'dummy-id'
+    });
+    vi.mocked(getRoleByItem).mockResolvedValue(
+      new MemberRole('ItemUpdater', 'Updates items and does nothing else', {
+        canUpdateItems: true
+      })
+    );
+    vi.mocked(querySectionInList).mockResolvedValue(true);
+    vi.mocked(updateItemSection).mockResolvedValue(true);
+
+    const response = await PATCH(
+      new Request(ITEM_PATH, {
+        method: 'patch',
+        body: JSON.stringify({ sectionId: 'asdfasdfasdfasdf' })
+      }),
+      {
+        params: Promise.resolve({ id: MOCK_ITEM.id })
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateItemSection).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      'asdfasdfasdfasdf'
     );
   });
 
@@ -149,6 +183,41 @@ describe('PATCH', () => {
 
       expect(response.status).toBe(403);
       expect(updateListItem).not.toHaveBeenCalled();
+    });
+
+    test('Rejects requests to move an item to a section that is part of a different list', async () => {
+      vi.mocked(getUser).mockResolvedValue(MOCK_USER);
+      vi.mocked(getRoleByItem).mockResolvedValue(
+        new MemberRole('DoesAllThings', 'Does everything', {
+          canAddItems: true,
+          canUpdateItems: true,
+          canDeleteItems: true,
+          canManageTags: true,
+          canManageAssignees: true,
+          canManageMembers: true,
+          canUpdateList: true,
+          canDeleteList: true
+        })
+      );
+      vi.mocked(getListItemById).mockResolvedValue({
+        ...MOCK_ITEM,
+        listId: 'dummy-id'
+      });
+      vi.mocked(querySectionInList).mockResolvedValue(false);
+
+      const response = await PATCH(
+        new Request(ITEM_PATH, {
+          method: 'patch',
+          body: JSON.stringify({ sectionId: 'asdfasdfasdfasdf' })
+        }),
+        {
+          params: Promise.resolve({ id: MOCK_ITEM.id })
+        }
+      );
+
+      expect(querySectionInList).toBeCalledWith('dummy-id', 'asdfasdfasdfasdf');
+      expect(response.status).toBe(400);
+      expect(updateItemSection).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/api/item/[id]/route.test.ts
+++ b/app/api/item/[id]/route.test.ts
@@ -38,7 +38,7 @@ const MOCK_USER = new User(
   new Date(),
   { color: 'Amber' }
 );
-const MOCK_ITEM = new ListItem('test tag', {});
+const MOCK_ITEM = new ListItem('test tag', 'dummySection', {});
 const ITEM_PATH = `http://localhost/api/item/${MOCK_ITEM.id}` as const;
 
 vi.mock('@/lib/session');
@@ -52,7 +52,10 @@ beforeEach(() => {
 describe('PATCH', () => {
   test('Updates item name when provided & requestor has permissions', async () => {
     vi.mocked(getUser).mockResolvedValue(MOCK_USER);
-    vi.mocked(getListItemById).mockResolvedValue(MOCK_ITEM);
+    vi.mocked(getListItemById).mockResolvedValue({
+      ...MOCK_ITEM,
+      listId: 'dummy-id'
+    });
     vi.mocked(getRoleByItem).mockResolvedValue(
       new MemberRole('ItemUpdater', 'Updates items and does nothing else', {
         canUpdateItems: true
@@ -96,7 +99,10 @@ describe('PATCH', () => {
 
     test("Indicates no resource exists if requestor is not a member of the list they're updating an item of", async () => {
       vi.mocked(getUser).mockResolvedValue(MOCK_USER);
-      vi.mocked(getListItemById).mockResolvedValue(MOCK_ITEM);
+      vi.mocked(getListItemById).mockResolvedValue({
+        ...MOCK_ITEM,
+        listId: 'dummy-id'
+      });
       vi.mocked(getRoleByItem).mockResolvedValue(false);
 
       const response = await PATCH(
@@ -115,7 +121,10 @@ describe('PATCH', () => {
 
     test('Rejects request if requestor has insufficient permissions to update item', async () => {
       vi.mocked(getUser).mockResolvedValue(MOCK_USER);
-      vi.mocked(getListItemById).mockResolvedValue(MOCK_ITEM);
+      vi.mocked(getListItemById).mockResolvedValue({
+        ...MOCK_ITEM,
+        listId: 'dummy-id'
+      });
       vi.mocked(getRoleByItem).mockResolvedValue(
         new MemberRole('NotItemUpdater', 'Does everything but update items', {
           canAddItems: true,

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -21,6 +21,7 @@ import { getRoleByItem } from '@/lib/database/user';
 import {
   deleteListItem,
   getListItemById,
+  updateItemSection,
   updateListItem
 } from '@/lib/database/listItem';
 import { getUser } from '@/lib/session';
@@ -28,9 +29,8 @@ import { ZodListItem } from '@/lib/model/listItem';
 
 const PatchBody = ZodListItem.omit({
   id: true,
-  sectionIndex: true,
-  sectionId: true
-}).partial();
+  sectionIndex: true
+}).partial()
 
 export async function PATCH(
   request: Request,
@@ -58,26 +58,32 @@ export async function PATCH(
 
   const requestBody = parseResult.data;
 
-  if (requestBody.name) item.name = requestBody.name;
-  if (requestBody.status) item.status = requestBody.status;
-  if (requestBody.priority) item.priority = requestBody.priority;
-  if (requestBody.dateDue) item.dateDue = new Date(requestBody.dateDue);
-  if (requestBody.expectedMs) item.expectedMs = requestBody.expectedMs;
-  if (requestBody.elapsedMs !== undefined)
-    item.elapsedMs = requestBody.elapsedMs;
-  if (requestBody.dateStarted !== undefined)
-    item.dateStarted = requestBody.dateStarted
-      ? new Date(requestBody.dateStarted)
-      : null;
-  if (requestBody.dateCompleted !== undefined)
-    item.dateCompleted = requestBody.dateCompleted
-      ? new Date(requestBody.dateCompleted)
-      : null;
+  if (requestBody.sectionId !== undefined) {
+    const res = await updateItemSection(item, requestBody.sectionId);
+    
+    if (!res) return ServerError.Internal('Failed to change section');
 
-  const result = await updateListItem(item);
-
-  if (!result) return ServerError.Internal('Could not update item');
-
+  } else {
+    if (requestBody.name) item.name = requestBody.name;
+    if (requestBody.status) item.status = requestBody.status;
+    if (requestBody.priority) item.priority = requestBody.priority;
+    if (requestBody.dateDue) item.dateDue = new Date(requestBody.dateDue);
+    if (requestBody.expectedMs) item.expectedMs = requestBody.expectedMs;
+    if (requestBody.elapsedMs !== undefined)
+      item.elapsedMs = requestBody.elapsedMs;
+    if (requestBody.dateStarted !== undefined)
+      item.dateStarted = requestBody.dateStarted
+        ? new Date(requestBody.dateStarted)
+        : null;
+    if (requestBody.dateCompleted !== undefined)
+      item.dateCompleted = requestBody.dateCompleted
+        ? new Date(requestBody.dateCompleted)
+        : null;
+  
+    const result = await updateListItem(item);
+  
+    if (!result) return ServerError.Internal('Could not update item');
+  }
   return Success.OK('Item updated');
 }
 

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -30,7 +30,7 @@ import { ZodListItem } from '@/lib/model/listItem';
 const PatchBody = ZodListItem.omit({
   id: true,
   sectionIndex: true
-}).partial()
+}).partial();
 
 export async function PATCH(
   request: Request,
@@ -60,9 +60,8 @@ export async function PATCH(
 
   if (requestBody.sectionId !== undefined) {
     const res = await updateItemSection(item, requestBody.sectionId);
-    
-    if (!res) return ServerError.Internal('Failed to change section');
 
+    if (!res) return ServerError.Internal('Failed to change section');
   } else {
     if (requestBody.name) item.name = requestBody.name;
     if (requestBody.status) item.status = requestBody.status;
@@ -79,11 +78,12 @@ export async function PATCH(
       item.dateCompleted = requestBody.dateCompleted
         ? new Date(requestBody.dateCompleted)
         : null;
-  
+
     const result = await updateListItem(item);
-  
+
     if (!result) return ServerError.Internal('Could not update item');
   }
+
   return Success.OK('Item updated');
 }
 

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -60,9 +60,8 @@ export async function PATCH(
   const requestBody = parseResult.data;
 
   if (requestBody.sectionId !== undefined) {
-    // TODO Why is ListID also not confirmed?
     const allowed = await querySectionInList(
-      item.listId!,
+      item.listId,
       requestBody.sectionId
     );
 

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -59,7 +59,7 @@ export async function PATCH(
 
   const requestBody = parseResult.data;
 
-  if (requestBody.sectionId !== undefined) {
+  if (requestBody.sectionId) {
     const allowed = await querySectionInList(
       item.listId,
       requestBody.sectionId

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -26,6 +26,7 @@ import {
 } from '@/lib/database/listItem';
 import { getUser } from '@/lib/session';
 import { ZodListItem } from '@/lib/model/listItem';
+import { querySectionInList } from '@/lib/database/list';
 
 const PatchBody = ZodListItem.omit({
   id: true,
@@ -59,6 +60,13 @@ export async function PATCH(
   const requestBody = parseResult.data;
 
   if (requestBody.sectionId !== undefined) {
+    // TODO Why is ListID also not confirmed?
+    const allowed = await querySectionInList(
+      item.listId!,
+      requestBody.sectionId
+    );
+
+    if (!allowed) return ClientError.BadRequest('Section not found');
     const res = await updateItemSection(item, requestBody.sectionId);
 
     if (!res) return ServerError.Internal('Failed to change section');

--- a/app/api/item/[id]/route.ts
+++ b/app/api/item/[id]/route.ts
@@ -86,7 +86,8 @@ export async function PATCH(
         ? new Date(requestBody.dateCompleted)
         : null;
 
-    const result = await updateListItem(item);
+    const {listId, ...pureItem} = item;
+    const result = await updateListItem(pureItem);
 
     if (!result) return ServerError.Internal('Could not update item');
   }

--- a/app/api/item/route.ts
+++ b/app/api/item/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
   if (!expectedMs && list.hasTimeTracking)
     return ClientError.BadRequest('Invalid expected duration');
 
-  const listItem = new ListItem(name, {
+  const listItem = new ListItem(name, requestBody.sectionId, {
     priority,
     expectedMs,
     sectionIndex,

--- a/components/List/__tests__/List.test.tsx
+++ b/components/List/__tests__/List.test.tsx
@@ -74,7 +74,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', { id: 'item-id' })
+                  new ListItem('List item name', 'setion-id', { id: 'item-id' })
                 ])
               ],
               true,
@@ -129,7 +129,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     priority: 'High',
                     id: 'item-id'
                   })
@@ -180,7 +180,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     status: 'In_Progress',
                     id: 'item-id'
                   })
@@ -235,7 +235,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     status: 'In_Progress',
                     id: 'item-id'
                   })
@@ -292,7 +292,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     status: 'Completed',
                     dateCompleted: new Date('2026-01-01'),
                     id: 'item-id'
@@ -350,7 +350,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     status: 'Completed',
                     dateCompleted: new Date('2026-01-01'),
                     id: 'item-id'
@@ -415,7 +415,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     id: 'item-id'
                   })
                 ])
@@ -481,7 +481,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     id: 'item-id'
                   })
                 ])
@@ -535,7 +535,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     id: 'item-id',
                     tags: [new Tag('Tag name', 'Emerald', 'tag-id')]
                   })
@@ -585,7 +585,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     expectedMs: 1000 * 60,
                     id: 'item-id'
                   })
@@ -642,7 +642,7 @@ describe('ListItem state propagation', () => {
                 [],
                 [
                   new ListSection('List section name', [
-                    new ListItem('List item name', {
+                    new ListItem('List item name', 'section-id', {
                       status: 'Unstarted',
                       elapsedMs: 0,
                       id: 'item-id'
@@ -698,7 +698,7 @@ describe('ListItem state propagation', () => {
                 [],
                 [
                   new ListSection('List section name', [
-                    new ListItem('List item name', {
+                    new ListItem('List item name', 'section-id', {
                       status: 'In_Progress',
                       elapsedMs: 2000 * 60,
                       id: 'item-id'
@@ -759,7 +759,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     status: 'Paused',
                     elapsedMs: 1000 * 60 * 5,
                     id: 'item-id'
@@ -815,7 +815,7 @@ describe('ListItem state propagation', () => {
               [],
               [
                 new ListSection('List section name', [
-                  new ListItem('List item name', {
+                  new ListItem('List item name', 'section-id', {
                     id: 'item-id'
                   })
                 ])

--- a/components/ListItem/__tests__/ListItem.test.tsx
+++ b/components/ListItem/__tests__/ListItem.test.tsx
@@ -54,7 +54,7 @@ beforeEach(vi.resetAllMocks);
 afterAll(vi.unstubAllEnvs);
 
 it('Shows everything faded and shows the completion date instead of due date when the item is marked completed', () => {
-  const item = new ListItemModel('Test item', {
+  const item = new ListItemModel('Test item', 'section-id', {
     priority: 'High',
     status: 'Completed',
     expectedMs: 5000 * 60,
@@ -96,7 +96,7 @@ it('Displays the associated list when one is provided', () => {
         dispatchItemChange={vi.fn()}
         hasDueDates={false}
         hasTimeTracking={false}
-        item={new ListItemModel('Test item', {})}
+        item={new ListItemModel('Test item', 'section-id', {})}
         list={
           new List('List Name', 'Cyan', [], [], false, false, false, 'list-id')
         }
@@ -137,7 +137,7 @@ it('Displays all members assigned to the item', () => {
       { color: 'Blue' }
     )
   ];
-  const item = new ListItemModel('Test item', {
+  const item = new ListItemModel('Test item', 'section-id', {
     assignees: [new Assignee(members[0], ''), new Assignee(members[1], '')]
   });
 

--- a/components/ListSection/AddItem.tsx
+++ b/components/ListSection/AddItem.tsx
@@ -175,7 +175,7 @@ export default function AddItem({
         const id = res.content?.split('/').at(-1);
 
         addItem(
-          new ListItem(values.name, {
+          new ListItem(values.name, sectionId, {
             priority,
             expectedMs: newItem.expectedMs,
             sectionIndex: nextIndex,

--- a/components/ListSection/__tests__/ListSection.test.tsx
+++ b/components/ListSection/__tests__/ListSection.test.tsx
@@ -125,7 +125,7 @@ describe('Section expansion/collapse', () => {
           items: new Map([
             [
               'aaaaaaaaaaaaaaaa',
-              new ListItem('Item 1', {
+              new ListItem('Item 1', 'section-id', {
                 id: 'aaaaaaaaaaaaaaaa',
                 status: 'Unstarted'
               })
@@ -158,7 +158,7 @@ describe('Section expansion/collapse', () => {
           items: new Map([
             [
               'aaaaaaaaaaaaaaaa',
-              new ListItem('Item 1', {
+              new ListItem('Item 1', 'section-id', {
                 id: 'aaaaaaaaaaaaaaaa',
                 status: 'Completed',
                 dateCompleted: new Date()
@@ -215,7 +215,7 @@ describe('Section expansion/collapse', () => {
           items: new Map([
             [
               'aaaaaaaaaaaaaaaa',
-              new ListItem('Item 1', {
+              new ListItem('Item 1', 'section-id', {
                 id: 'aaaaaaaaaaaaaaaa',
                 status: 'Completed',
                 dateCompleted: new Date()
@@ -253,7 +253,7 @@ describe('Section expansion/collapse', () => {
           items: new Map([
             [
               'aaaaaaaaaaaaaaaa',
-              new ListItem('Item 1', {
+              new ListItem('Item 1', 'section-id', {
                 id: 'aaaaaaaaaaaaaaaa',
                 status: 'Unstarted'
               })

--- a/lib/__tests__/sort.test.ts
+++ b/lib/__tests__/sort.test.ts
@@ -36,24 +36,24 @@ afterAll(() => {
 describe('sortItemsByCompleted', () => {
   test('Incomplete items are sorted before completed items', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted',
         dateCompleted: null
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted',
         dateCompleted: null
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
@@ -67,24 +67,24 @@ describe('sortItemsByCompleted', () => {
 
   test('Incomplete items stay before completed items', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted',
         dateCompleted: null
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted',
         dateCompleted: null
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
@@ -98,24 +98,24 @@ describe('sortItemsByCompleted', () => {
 
   test('Items completed most recent are sorted before items completed longer ago', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:45.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:45.000Z')
@@ -129,24 +129,24 @@ describe('sortItemsByCompleted', () => {
 
   test('Items completed most recent stay before items completed longer ago', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:45.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:47.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-24T01:23:45.000Z')
@@ -160,24 +160,24 @@ describe('sortItemsByCompleted', () => {
 
   test('Items completed at the same time are both returned with order unspecified', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-26T03:36:23.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-26T03:36:23.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-26T03:36:23.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Completed',
         dateCompleted: new Date('2024-07-26T03:36:23.000Z')
@@ -191,21 +191,21 @@ describe('sortItemsByCompleted', () => {
 
   test('Incomplete items are not reordered', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted'
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted'
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted'
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         status: 'Unstarted'
       })
@@ -220,13 +220,25 @@ describe('sortItemsByCompleted', () => {
 describe('sortItemsByIndex()', () => {
   test('Items are sorted in ascending order by index', () => {
     const data = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 2 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 2
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      })
     ];
 
     const expected = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 2
+      })
     ];
 
     const result = data.toSorted(sortItemsByIndex);
@@ -236,13 +248,25 @@ describe('sortItemsByIndex()', () => {
 
   test('Items in ascending order are  not reordered', () => {
     const data = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 2
+      })
     ];
 
     const expected = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 2
+      })
     ];
 
     const result = data.toSorted(sortItemsByIndex);
@@ -252,13 +276,25 @@ describe('sortItemsByIndex()', () => {
 
   test('Items with the same index are both returned with order unspecified', () => {
     const data = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      })
     ];
 
     const expected = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', sectionIndex: 1 })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        sectionIndex: 1
+      })
     ];
 
     const result = data.toSorted(sortItemsByIndex);
@@ -270,8 +306,11 @@ describe('sortItemsByIndex()', () => {
 describe('sortItemsByOrder', () => {
   test('Items are sorted in ascending order by order value', () => {
     const data = [
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 }),
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-2',
+        sectionIndex: 2
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-1', sectionIndex: 1 })
     ];
     const order = new Map([
       ['item-1', 1],
@@ -279,8 +318,11 @@ describe('sortItemsByOrder', () => {
     ]);
 
     const expected = [
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-1',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-2', sectionIndex: 2 })
     ];
 
     const result = data.toSorted(sortItemsByOrder.bind(null, order));
@@ -290,8 +332,11 @@ describe('sortItemsByOrder', () => {
 
   test('Items in ascending order are not reordered', () => {
     const data = [
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-1',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-2', sectionIndex: 2 })
     ];
     const order = new Map([
       ['item-1', 1],
@@ -299,8 +344,11 @@ describe('sortItemsByOrder', () => {
     ]);
 
     const expected = [
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-1',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-2', sectionIndex: 2 })
     ];
 
     const result = data.toSorted(sortItemsByOrder.bind(null, order));
@@ -310,8 +358,11 @@ describe('sortItemsByOrder', () => {
 
   test('Throws an error if item a is not included in the order map', () => {
     const data = [
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-1',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-2', sectionIndex: 2 })
     ];
     const order = new Map([['item-2', 2]]);
 
@@ -322,8 +373,11 @@ describe('sortItemsByOrder', () => {
 
   test('Throws an error if item b is not included in the order map', () => {
     const data = [
-      new ListItem('Some item', { id: 'item-1', sectionIndex: 1 }),
-      new ListItem('Some item', { id: 'item-2', sectionIndex: 2 })
+      new ListItem('Some item', 'section-id', {
+        id: 'item-1',
+        sectionIndex: 1
+      }),
+      new ListItem('Some item', 'section-id', { id: 'item-2', sectionIndex: 2 })
     ];
     const order = new Map([['item-1', 1]]);
 
@@ -336,12 +390,24 @@ describe('sortItemsByOrder', () => {
 describe('sortItems', () => {
   test('High priority items are sorted before low priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -351,12 +417,24 @@ describe('sortItems', () => {
 
   test('High priority items stay before low priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -366,12 +444,24 @@ describe('sortItems', () => {
 
   test('High priority items are sorted before medium priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -381,12 +471,24 @@ describe('sortItems', () => {
 
   test('High priority items stay before medium priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'High' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'High'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -396,12 +498,24 @@ describe('sortItems', () => {
 
   test('Medium priority items are sorted before low priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -411,12 +525,24 @@ describe('sortItems', () => {
 
   test('Medium priority items stay before low priority ones', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Medium' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', priority: 'Low' })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Medium'
+      }),
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        priority: 'Low'
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, false));
@@ -426,21 +552,21 @@ describe('sortItems', () => {
 
   test('When due dates are active, items due first are sorted before items due later', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-25T00:00:00.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-25T00:00:00.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
@@ -453,21 +579,21 @@ describe('sortItems', () => {
 
   test('When due dates are active, items due first stay before items due later', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-25T00:00:00.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-25T00:00:00.000Z')
       }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
@@ -480,15 +606,21 @@ describe('sortItems', () => {
 
   test('When due dates are active, items without due dates are sorted before item with due dates', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null })
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      }),
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
@@ -501,15 +633,21 @@ describe('sortItems', () => {
 
   test('When due dates are active, items without due dates stay before item with due dates', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      }),
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null }),
-      new ListItem('Some item', {
+      new ListItem('Some item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      }),
+      new ListItem('Some item', 'section-id', {
         id: 'aaaaaaaaaaaaaaaa',
         dateDue: new Date('2024-07-27T00:00:00.000Z')
       })
@@ -522,12 +660,24 @@ describe('sortItems', () => {
 
   test('When due dates are active, items without due dates are not reordered relative to each other', () => {
     const data: ListItem[] = [
-      new ListItem('First item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null }),
-      new ListItem('Second item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null })
+      new ListItem('First item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      }),
+      new ListItem('Second item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      })
     ];
     const expected: ListItem[] = [
-      new ListItem('First item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null }),
-      new ListItem('Second item', { id: 'aaaaaaaaaaaaaaaa', dateDue: null })
+      new ListItem('First item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      }),
+      new ListItem('Second item', 'section-id', {
+        id: 'aaaaaaaaaaaaaaaa',
+        dateDue: null
+      })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, true));
@@ -537,12 +687,12 @@ describe('sortItems', () => {
 
   test('Identical items are both returned', () => {
     const data: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa' })
+      new ListItem('Some item', 'section-id', { id: 'aaaaaaaaaaaaaaaa' }),
+      new ListItem('Some item', 'section-id', { id: 'aaaaaaaaaaaaaaaa' })
     ];
     const expected: ListItem[] = [
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa' }),
-      new ListItem('Some item', { id: 'aaaaaaaaaaaaaaaa' })
+      new ListItem('Some item', 'section-id', { id: 'aaaaaaaaaaaaaaaa' }),
+      new ListItem('Some item', 'section-id', { id: 'aaaaaaaaaaaaaaaa' })
     ];
 
     const result = data.toSorted(sortItems.bind(null, false, true));

--- a/lib/database/list.ts
+++ b/lib/database/list.ts
@@ -378,3 +378,19 @@ export async function deleteTag(id: string): Promise<boolean> {
 
   return true;
 }
+
+/**
+ * Queries if a sectionId is in a listId
+ * @param listId The list to query sections of
+ * @param sectionId The target section to find
+ */
+export async function querySectionInList(
+  listId: string,
+  sectionId: string
+): Promise<boolean> {
+  const result = await prisma.listSection.findUnique({
+    where: { id: sectionId, listId }
+  });
+
+  return Boolean(result);
+}

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -193,3 +193,53 @@ export async function unlinkAssignee(
 
   return true;
 }
+
+/**
+ *  Move a List Item from its current section to a new section given by sectionId.
+ * The selected item is appended to the end of that new section.
+ * @param item The ListItem to change the section of
+ * @param sectionId The sectionId of the target Section
+ */
+export async function updateItemSection(
+  item: ListItem,
+  sectionId: string
+): Promise<boolean> {
+  try {
+    await prisma.$transaction(
+      async tx => {
+        
+        const targetSectionCount = await tx.item.count({
+          where: { sectionId }
+        })
+        const originalIndex =item.sectionIndex;
+        
+        await tx.item.update({
+          where: { id: item.id },
+          data: {
+            sectionId,
+            sectionIndex: targetSectionCount + 1
+          }          
+        });
+
+        await tx.item.updateMany({
+          where: {
+            sectionId: "foo", //TODO How to get (cleanly) Original Section,
+            sectionIndex: {
+              gte: originalIndex,
+            },
+          },
+          data: {
+            sectionIndex: {
+              decrement: 1,
+            },
+          },
+        });
+
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+  } catch {
+    return false;
+  }
+  return true;
+}

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -220,7 +220,7 @@ export async function updateItemSection(
   try {
     await prisma.$transaction(
       async tx => {
-        const targetSectionCount = await tx.item.count({
+        const targetSectionItems = await tx.item.count({
           where: { sectionId }
         });
         const originalIndex = item.sectionIndex;
@@ -229,7 +229,7 @@ export async function updateItemSection(
           where: { id: item.id },
           data: {
             sectionId,
-            sectionIndex: targetSectionCount + 1
+          sectionIndex: targetSectionItems + 1
           }
         });
         await tx.item.updateMany({

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -39,13 +39,26 @@ export async function createListItem(
   return true;
 }
 
-export async function getListItemById(id: string): Promise<ListItem | false> {
+export async function getListItemById(
+  id: string
+): Promise<(ListItem & { listId: string }) | false> {
   const result = await prisma.item.findUnique({
     where: { id },
-    include: { tags: true, assignees: { include: { user: true } } }
+    include: {
+      tags: true,
+      assignees: { include: { user: true } },
+      section: {
+        select: { listId: true }
+      }
+    }
   });
 
-  return result ?? false;
+  if (!result) return false;
+
+  return {
+    ...result,
+    listId: result.section.listId
+  };
 }
 
 export async function getListItemsByUser(userId: string): Promise<ListItem[]> {
@@ -219,10 +232,9 @@ export async function updateItemSection(
             sectionIndex: targetSectionCount + 1
           }
         });
-
         await tx.item.updateMany({
           where: {
-            sectionId: 'foo', //TODO How to get (cleanly) Original Section,
+            sectionId: item.sectionId,
             sectionIndex: {
               gte: originalIndex
             }

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -207,39 +207,38 @@ export async function updateItemSection(
   try {
     await prisma.$transaction(
       async tx => {
-        
         const targetSectionCount = await tx.item.count({
           where: { sectionId }
-        })
-        const originalIndex =item.sectionIndex;
-        
+        });
+        const originalIndex = item.sectionIndex;
+
         await tx.item.update({
           where: { id: item.id },
           data: {
             sectionId,
             sectionIndex: targetSectionCount + 1
-          }          
+          }
         });
 
         await tx.item.updateMany({
           where: {
-            sectionId: "foo", //TODO How to get (cleanly) Original Section,
+            sectionId: 'foo', //TODO How to get (cleanly) Original Section,
             sectionIndex: {
-              gte: originalIndex,
-            },
+              gte: originalIndex
+            }
           },
           data: {
             sectionIndex: {
-              decrement: 1,
-            },
-          },
+              decrement: 1
+            }
+          }
         });
-
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
     );
   } catch {
     return false;
   }
+
   return true;
 }

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -208,7 +208,7 @@ export async function unlinkAssignee(
 }
 
 /**
- *  Move a List Item from its current section to a new section given by sectionId.
+ * Move a List Item from its current section to a new section given by sectionId.
  * The selected item is appended to the end of that new section.
  * @param item The ListItem to change the section of
  * @param sectionId The sectionId of the target Section
@@ -229,7 +229,7 @@ export async function updateItemSection(
           where: { id: item.id },
           data: {
             sectionId,
-          sectionIndex: targetSectionItems + 1
+          sectionIndex: targetSectionItems
           }
         });
         await tx.item.updateMany({

--- a/lib/database/listItem.ts
+++ b/lib/database/listItem.ts
@@ -54,10 +54,10 @@ export async function getListItemById(
   });
 
   if (!result) return false;
-
+  const {section, ...item} = result;
   return {
-    ...result,
-    listId: result.section.listId
+    ...item,
+    listId: section.listId
   };
 }
 
@@ -120,7 +120,8 @@ export async function updateListItem(
         sectionId: undefined
       }
     });
-  } catch {
+  } catch (err){
+    console.log(err)
     return false;
   }
 

--- a/lib/model/__tests__/listItem.test.ts
+++ b/lib/model/__tests__/listItem.test.ts
@@ -33,21 +33,23 @@ beforeEach(() => {
 
 describe('ListItem constructor', () => {
   test('Generates an id if none provided', () => {
-    const listItem = new ListItem('testListItem', {});
+    const listItem = new ListItem('testListItem', 'section-id', {});
 
     expect(listItem.id).toBe('mock-generated-id');
     expect(generateId).toHaveBeenCalled();
   });
 
   test('Uses the provided id', () => {
-    const listItem = new ListItem('testListItem', { id: 'provided-id' });
+    const listItem = new ListItem('testListItem', 'section-id', {
+      id: 'provided-id'
+    });
 
     expect(listItem.id).toBe('provided-id');
     expect(generateId).not.toHaveBeenCalled();
   });
 
   test('Uses sane defaults for a new item when properties are unspecified', () => {
-    const listItem = new ListItem('testListItem', {});
+    const listItem = new ListItem('testListItem', 'section-id', {});
 
     expect(listItem.status).toBe('Unstarted');
     expect(listItem.priority).toBe('Low');
@@ -79,7 +81,7 @@ describe('ListItem constructor', () => {
     ];
     const tags = [new Tag('tag1', 'Amber'), new Tag('tag2', 'Cyan')];
 
-    const listItem = new ListItem('testListItem', {
+    const listItem = new ListItem('testListItem', 'section-id', {
       status: 'Completed',
       priority: 'High',
       isUnclear: true,

--- a/lib/model/__tests__/listSection.test.ts
+++ b/lib/model/__tests__/listSection.test.ts
@@ -45,8 +45,8 @@ test('Uses the provided id', () => {
 
 test('Assigns all properties correctly', () => {
   const listItems = [
-    new ListItem('listItem1', {}),
-    new ListItem('listItem2', {})
+    new ListItem('listItem1', 'section-id', {}),
+    new ListItem('listItem2', 'section-id', {})
   ];
 
   const listSection = new ListSection(

--- a/lib/model/listItem.ts
+++ b/lib/model/listItem.ts
@@ -61,9 +61,11 @@ export default class ListItem {
   assignees: Assignee[];
   tags: Tag[];
   listId?: string;
+  sectionId: string;
 
   constructor(
     name: string,
+    sectionId: string,
     {
       id,
       status = 'Unstarted',
@@ -94,7 +96,6 @@ export default class ListItem {
       assignees?: Assignee[];
       tags?: Tag[];
       listId?: string;
-      sectionId?: string;
     }
   ) {
     if (!id) id = generateId();
@@ -114,5 +115,6 @@ export default class ListItem {
     this.assignees = assignees;
     this.tags = tags;
     this.listId = listId;
+    this.sectionId = sectionId;
   }
 }


### PR DESCRIPTION
Modifies the `PATCH /api/item/[id]` route to support section changes if the body includes `{'sectionId', [sectionId]}`

Related to #76 
>[!Note]
>Current CI results from hash `d6ab359f4e478af14dd50c70ea165da775fdf48a` are due to:
>- Test coverage not in scope for this PR
>- Linting Issues from the `change-section-dropdown` branch


