### PR TITLE
fix: prevent non-shared lists from blocking account deletion

### DIFF
--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -139,6 +139,7 @@ function AddList({ addList }: { addList: () => unknown }) {
   return (
     <Button
       isIconOnly
+      aria-label='Create new list'
       className='border-0 text-foreground rounded-lg w-8 h-8 min-w-8 min-h-8'
       color='primary'
       variant='ghost'
@@ -182,6 +183,7 @@ function NewItem({
       />
       <Button
         isIconOnly
+        aria-label='Submit list'
         className='rounded-lg w-8 h-8 min-w-8 min-h-8'
         color='primary'
         type='submit'

--- a/cypress/e2e/auth/deleteAccount.cy.ts
+++ b/cypress/e2e/auth/deleteAccount.cy.ts
@@ -87,4 +87,26 @@ describe('delete account', () => {
         cy.contains('Account succesfully deleted').should('be.visible');
       });
   });
+
+  it('Deletion succeeds as only admin of non-shared list', () => {
+    cy.login('newUser', 'password123');
+
+    cy.createList('dummyList');
+
+    cy.findByLabelText('Profile Actions Dropdown').click();
+    cy.findByLabelText('Profile').should('be.visible').click();
+
+    cy.findByLabelText('Delete Account').click();
+    cy.findByLabelText('Password').should('be.visible').type('password123');
+
+    cy.findByLabelText('Confirm Delete Account').click();
+
+    cy.location('pathname').should('eq', '/about');
+
+    cy.get('[data-toast="true"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Account succesfully deleted').should('be.visible');
+      });
+  });
 });

--- a/cypress/e2e/auth/deleteAccount.cy.ts
+++ b/cypress/e2e/auth/deleteAccount.cy.ts
@@ -93,7 +93,7 @@ describe('delete account', () => {
 
     cy.createList('dummyList');
 
-    cy.findByLabelText('Profile Actions Dropdown').click();
+    cy.findByLabelText('Profile actions').click();
     cy.findByLabelText('Profile').should('be.visible').click();
 
     cy.findByLabelText('Delete Account').click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -73,11 +73,22 @@ Cypress.Commands.add('login', (username: string, password: string) => {
     .and('not.be.null');
 });
 
+Cypress.Commands.add('createList', (listName: string) => {
+  cy.visit('/list');
+
+  cy.get('button .bi-plus').click();
+  cy.findByPlaceholderText('List name').type(listName);
+  cy.get('button[type="submit"]').click();
+
+  cy.location('pathname').should('match', /^\/list\/[a-zA-Z0-9]{16}$/);
+});
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
       login(email: string, password: string): Chainable<void>;
+      createList(listName: string): Chainable<void>;
     }
   }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -76,9 +76,9 @@ Cypress.Commands.add('login', (username: string, password: string) => {
 Cypress.Commands.add('createList', (listName: string) => {
   cy.visit('/list');
 
-  cy.get('button .bi-plus').click();
+  cy.findByLabelText('Create new list').click();
   cy.findByPlaceholderText('List name').type(listName);
-  cy.get('button[type="submit"]').click();
+  cy.findByLabelText('Submit list').click();
 
   cy.location('pathname').should('match', /^\/list\/[a-zA-Z0-9]{16}$/);
 });

--- a/lib/database/user.ts
+++ b/lib/database/user.ts
@@ -185,7 +185,7 @@ export async function getIsOnlyAdminOnSharedList(
             userId: { not: userId }
           },
           some: {
-            userId: { not: userId}
+            userId: { not: userId }
           }
         }
       }

--- a/lib/database/user.ts
+++ b/lib/database/user.ts
@@ -183,6 +183,9 @@ export async function getIsOnlyAdminOnSharedList(
           none: {
             role: { name: 'Admin' },
             userId: { not: userId }
+          },
+          some: {
+            userId: { not: userId}
           }
         }
       }


### PR DESCRIPTION
A bug in the database interface to check if a user was the last admin of a list proactively prevented deletion of users who were the only admin of a list that wasn't shared.

This fixes that bug and adds e2e testing to prevent future issues. 

## Related Issues

Closes #145 

## Changes
- [x] fixed bug in database function that checks last admin
- [x] added e2e test to verify behavior
- [x] added cypress command to create dummy test list  

## Testing Coverage
Tested via e2e tests, database action cannot be verified by in vitest

Test coverage issues from deepsource are out of scope for this PR, and will mostly be resolved with the normal vs Github List Modal