### PR TITLE
fix: users can't remove tag if not linked to any items

### DIFF
--- a/app/api/tag/[id]/route.ts
+++ b/app/api/tag/[id]/route.ts
@@ -71,7 +71,13 @@ export async function DELETE(
 
   const role = await getRoleByTag(user.id, id);
 
-  if (!role) return ClientError.NotFound('Tag not found');
+  if (!role) {
+    console.warn(
+      `${user.id} tried deleting ${id} which they don't have access to`
+    );
+
+    return ClientError.NotFound('Tag not found');
+  }
   if (!role.canManageTags)
     return ClientError.Forbidden('Insufficient permissions to remove tag');
 

--- a/lib/database/user.ts
+++ b/lib/database/user.ts
@@ -133,9 +133,7 @@ export async function getRoleByTag(
         some: {
           userId,
           list: {
-            sections: {
-              some: { items: { some: { tags: { some: { id: tagId } } } } }
-            }
+            tags: { some: { id: tagId } }
           }
         }
       }


### PR DESCRIPTION
Fixes a database query bug that makes tags seem like they're not linked to their list if they aren't assigned to at least 1 item.

## Testing

Since this affects the success of database queries, it cannot be tested via unit/integration tests. To validate that users can now delete tags that aren't linked to any items:
- Create a new tag on a list
- Try to delete it from the Settings modal when it's not linked to any items