### PR TITLE
docs: clarify self-hosting process and update README to reflect changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Tasktix is a task-tracking tool for power users, providing increased control and
 flexibility when creating and scheduling tasks. Most free task tracking tools fall short
 when it comes to advanced functionality, either entirely missing them or locking them
-behind paywalls. Our goal is to build a comprehensive tool that anyone can use for free
+behind paywalls. Our goal is to provide a comprehensive tool that anyone can use for free
 (or even self-host!) to boost efficiency and productivity without those limitations.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ behind paywalls. Our goal is to build a comprehensive tool that anyone can use f
 
 ## Getting Started
 
-### Usage
+If you are considering self-hosting Tasktix, check out our
+[self-hosting documentation](./docs/self_hosting.md). Setting it up with a minimal
+configuration for analysis takes less than 5 minutes!
 
-To start the development server after following the instructions above, simply run
-`npm start`. Any changes you make to the source will be immediately and automatically
-reflected on the website. To teardown the Docker container the development server is run
-from, run `npm run teardown`. You only need to do this if you want to reclaim the storage
-space that's being used by the container image. To simply halt container execution, press
-<kbd>Ctrl</kbd> + <kbd>C</kbd> from the shell running `npm start` or run `npm stop`.
+## Contributing
+
+Thank you for helping us make Tasktix the best task-tracking app for power users! Please
+note that everyone who interacts with this repo must adhere to
+[our code of conduct](./CODE_OF_CONDUCT.md). A few things you could do that would help
+drive Tasktix forward are:
+
+- **Create a bug report** so we can ensure Tasktix keeps advancing with minimal turbulence
+- **Submit a feature request** to help us decide where to take Tasktix next
+- **Signal interest** in existing issues using GitHub reactions (:thumbs-up:) on the top
+  post or relevant comments
+- Only add a comment if you bring *new, actionable information* (e.g. reproduction steps
+  for a bug or a concrete use case for a feature)
+- **Submit a PR** to bring your ideas to life! To get started, please check out
+  [our contribution guidelines](./CONTRIBUTING.md).

--- a/docs/self_hosting.md
+++ b/docs/self_hosting.md
@@ -1,8 +1,19 @@
-# Docker Compose
+# Self Hosting
+
+## Docker Compose
 
 To quickly start the project with Docker Compose, copy this `compose.yaml` and run
 `DB_DATABASE=your_db_name DB_PASSWORD=<your-password-here> docker compose up -d`. You'll
-also want to run `docker run --rm --network tasktix --env "DATABASE_URL=<your-database-url>" ghcr.io/tasktix/tasktix-deploy:latest` to set up your database schema.
+also want to run
+`docker run --rm --network tasktix --env "DATABASE_URL=<your-database-url>" ghcr.io/tasktix/tasktix-deploy:latest`
+to set up your database schema.
+
+> [!WARNING]
+> This is a **very minimal** configuration needed to start up Tasktix and test it out. It
+> **is not** recommended for production deployment for a number reasons, including the
+> ephemeral database that could result in **complete data loss**. For a more stable
+> deployment, we strongly recommend using Podman Quadlets as described below or expanding
+> this Compose file if you prefer using Docker.
 
 ```yaml
 name: tasktix
@@ -21,33 +32,44 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_DATABASE}
-    volumes:
-      - /path/on/your/host:/var/lib/mysql
 ```
 
-# Podman Quadlets
+## Podman Quadlets
 
-To start Tasktix more robustly as `systemd` services, you'll need to create files like
-these:
+To start Tasktix more robustly as `systemd` services, you'll need to create a number of
+definition files in your Quadlet configuration directory, `{base}`. For example, for
+rootless deployments on Fedora CoreOS, `{base}` is `~/.config/containers/systemd`. The
+file paths below are all relative to this directory.
 
-.config/containers/systemd/tasktix/tasktix-web.container
+> [!NOTE]
+> All secrets should be stored using Podman secrets. For example,
+> `TASKTIX_BETTER_AUTH_SECRET` can be generated and stored using:
+>
+> ```sh
+> openssl rand -base64 32 | podman secret create TASKTIX_BETTER_AUTH_SECRET -
+> ```
 
+### Configuration Files
+
+#### `tasktix.pod`
 ```ini
-[Container]
-Pod=tasktix.pod
-Image=ghcr.io/tasktix/tasktix-web
+[Pod]
+PodName=tasktix
+PublishPort=<HOST_BINDING>:3000
 
-Environment=BETTER_AUTH_URL=<PATH_TO_TASKTIX_ROOT>
+[Install]
+WantedBy=default.target
+```
+- `<HOST_BINDING>` (including the `<>`) should be replaced with the network binding on
+  your local machine. For example, if you publish with a reverse proxy and have port
+  3000 open, this could be `127.0.0.1:3000` to bind to your loopback address on port 3000.
 
-Secret=TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL
-Secret=TASKTIX_BETTER_AUTH_SECRET,type=env,target=BETTER_AUTH_SECRET
-
-[Service]
-Restart=unless-stopped
+#### `tasktix-db.volume`
+```ini
+[Volume]
 ```
 
-.config/containers/systemd/tasktix-db.container
-
+#### `tasktix-db.container`
 ```ini
 [Container]
 Pod=tasktix.pod
@@ -65,49 +87,114 @@ Secret=TASKTIX_DB_ROOT_PASSWORD,type=mount,target=/run/secrets/db_root_password
 [Service]
 Restart=always
 ```
+- `TASKTIX_DB_PASSWORD` and `TASKTIX_DB_ROOT_PASSWORD` should be long, secure passwords
+  that follow good password hygiene practices.
+
+#### `tasktix-web.container`
+```ini
+[Container]
+Pod=tasktix.pod
+Image=ghcr.io/tasktix/tasktix-web
+
+Environment=BETTER_AUTH_URL=<PATH_TO_TASKTIX_ROOT>
+
+Secret=TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL
+Secret=TASKTIX_BETTER_AUTH_SECRET,type=env,target=BETTER_AUTH_SECRET
+
+[Service]
+Restart=unless-stopped
+```
 - `<PATH_TO_TASKTIX_ROOT>` (including the `<>`) should be replaced with the URL to the
   root of your Tasktix deployment. For example, if you deploy to
   `https://tasktix.example.com`, that should be the specified path. If you deploy to
   `https://containers.example.com/tasktix`, that should be the specified path.
+- `TASKTIX_BETTER_AUTH_SECRET` should be securely generated, e.g. with
+  `openssl rand -base64 32`.
+- `TASKTIX_DATABASE_URL` needs to be a valid embedded credentials URL in the form
+  `mysql://tasktix:<TASKTIX_DB_PASSWORD>@tasktix/tasktix`, where `<TASKTIX_DB_PASSWORD>`
+  (including the `<>`) is replaced with value you set for the Podman secret with the same
+  name.
 
-.config/containers/systemd/tasktix-db.volume
+### Initial Startup
 
-```ini
-[Volume]
+After creating these files with your desired configuration and loading the corresponding
+Podman secrets, run these commands to start the server:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user start tasktix-pod
 ```
 
-.config/containers/systemd/tasktix.pod
-
-```ini
-[Pod]
-PodName=tasktix
-PublishPort=127.0.0.1:3000:3000
-
-[Install]
-WantedBy=default.target
+You'll also need to run the following command to set up your database:
+```sh
+podman run --rm --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
 ```
 
-Then run these commands to securely load your secrets into `podman` and start the server:
+> [!NOTE]
+> The deploy container currently does not respect `SIGTERM` or `SIGQUIT`. We recommend
+  running the above command with the `--detach` flag, giving it ~10 seconds to run, then
+  killing it with `podman stop`.
 
-```console
-foo@bar:~$ read
-<your-password-here>
-foo@bar:~$ echo "$REPLY" | podman secret create TASKTIX_DB_PASSWORD -
-foo@bar:~$ read
-mysql://tasktix:<your-password-here>@tasktix/tasktix
-foo@bar:~$ echo "$REPLY" | podman secret create TASKTIX_DATABASE_URL -
-foo@bar:~$ read
-<your-root-password-here>
-foo@bar:~$ echo "$REPLY" | podman secret create TASKTIX_DB_PASSWORD -
-foo@bar:~$ unset $REPLY
-foo@bar:~$ openssl rand -base64 32 | podman secret create TASKTIX_BETTER_AUTH_SECRET -
-foo@bar:~$ systemctl --user daemon-reload
-foo@bar:~$ systemctl --user start tasktix-pod
-foo@bar:~$ podman run --rm --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
+### Configuration
+
+As the administrator for your Tasktix instance, you can customize some of Tasktix's
+behavior to better align with your (or your organization's) needs.
+
+#### Authentication Customization
+
+To customize how Tasktix handles authentication, you can adjust `tasktix-web.container`.
+After changing the file, you will need to run these commands to apply the changes:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user restart tasktix-web
 ```
 
-After setting up the project, you may want to add additional roles beyond the Admin role
-for users to limit list members' permissions. Some sensible defaults might look like this:
+- To disable local username/password authentication:
+  ```ini
+  Environment=DISABLE_LOCAL_AUTH=true
+  ```
+
+- To allow passwords that've shown up in prior data breaches:
+  ```ini
+  Environment=DISABLE_PASSWORD_STRENGTH_CHECK=true
+  ```
+  This is **strongly discouraged** because it is very easy for hackers to compromise these
+  accounts.
+
+- To enable GitHub SSO authentication:
+  ```ini
+  Environment=GITHUB_CLIENT_ID=<YOUR_CLIENT_ID>
+  Secret=TASKTIX_GITHUB_SECRET,type=env,target=GITHUB_CLIENT_SECRET
+  ```
+  See [`docs/auth.md`](./auth.md) for more details on setting `GITHUB_CLIENT_ID` and
+  `TASKTIX_GITHUB_SECRET`.
+
+- To enable OIDC authentication:
+  ```ini
+  Environment=OAUTH_PROVIDER_ID=<YOUR_PROVIDER_NAME>
+  Environment=OAUTH_DISCOVERY_URL=<YOUR_PROVIDER_DISCOVERY_URL>
+  Environment=OAUTH_CLIENT_ID=<YOUR_CLIENT_ID>
+  Secret=TASKTIX_OAUTH_SECRET,type=env,target=OAUTH_CLIENT_SECRET
+  ```
+  `<YOUR_PROVIDER_NAME>` is the name that users will see for this sign-in option. If your
+  provider does not support discovery URLs, you can instead provide
+  `OAUTH_AUTHORIZATION_URL`, `OAUTH_TOKEN_URL`, and `OAUTH_USERINFO_URL` environment
+  variables.
+
+#### List Member Roles
+
+You may want to add additional roles beyond the Admin role to limit list members'
+permissions. All role customization must be done directly in the database. To access the
+database's SQL interface, you can run:
+
+```sh
+podman exec -it tasktix-db mariadb tasktix -utasktix -p
+```
+
+Then, enter the non-root password that you created when you set up Tasktix.
+
+Some sensible defaults might look like this:
 ```sql
 INSERT INTO `MemberRole` (
   `id`,
@@ -182,4 +269,30 @@ INSERT INTO `MemberRole` (
   FALSE,
   FALSE
 );
+```
+
+### Updates
+
+To update Tasktix to a newer version, we recommend first stopping the webserver so clients
+don't make changes
+mid-migration:
+
+```sh
+systemctl --user stop tasktix-web
+```
+
+Then, pull the latest version of the `tasktix-web` and `tasktix-deploy` containers:
+```sh
+podman pull ghcr.io/tasktix-web:latest
+podman pull ghcr.io/tasktix-deploy:latest
+```
+
+Next, run the `tasktix-deploy` container to update your database's configuration:
+```sh
+podman run --rm -d --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
+```
+
+Finally, start the webserver again:
+```sh
+systemctl --user start tasktix-web
 ```

--- a/docs/self_hosting.md
+++ b/docs/self_hosting.md
@@ -127,7 +127,7 @@ systemctl --user start tasktix-pod
 
 You'll also need to run the following command to set up your database:
 ```sh
-podman run --rm --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
+podman run --rm --detach --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Clarifies self-hosting docs for easier independent setup. Also updates the README to reflect the current project state.

## Related Issues

- Temporary fix for to #116  
- Closes #133
- Closes #143

## Reviewer Notes
Do these updates reflect all of our goals from these issues? Should anything else be added?