### PR TITLE
chore: improve build consistency and speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,75 +8,45 @@ on:
 
 jobs:
   build_web:
-    runs-on: ubuntu-latest
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
+    with:
+      output: image
+      push: true
+      meta-images: ghcr.io/tasktix/tasktix-web
+      annotations: |
+        org.opencontainers.image.source=https://github.com/Tasktix/Tasktix
+        org.opencontainers.image.description=A powerful and flexible task-tracking tool for all.
+        org.opencontainers.image.licenses=AGPL-3.0-or-later
+      meta-tags: latest
+      platforms: linux/amd64,linux/arm64
+      fail-fast: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build web image metadata
-        id: meta-web
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/tasktix/tasktix-web
-          labels: |
-            org.opencontainers.image.source=https://github.com/Tasktix/Tasktix
-            org.opencontainers.image.description=A powerful and flexible task-tracking tool for all.
-            org.opencontainers.image.licenses=AGPL-3.0-or-later
-          tags: |
-            latest
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-      - name: Build and push web image
-        uses: docker/build-push-action@v6
-        with:
-          annotations: ${{ steps.meta-web.outputs.annotations }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta-web.outputs.tags }}
 
   build_deploy:
-    runs-on: ubuntu-latest
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build deploy image metadata
-        id: meta-deploy
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/tasktix/tasktix-deploy
-          annotations: |
-            org.opencontainers.image.description=A powerful and flexible task-tracking tool for all.
-            org.opencontainers.image.licenses=AGPL-3.0-or-later
-          tags: |
-            latest
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
-      - name: Build and push deploy image
-        uses: docker/build-push-action@v6
-        with:
-          annotations: ${{ steps.meta-deploy.outputs.annotations }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta-deploy.outputs.tags }}
-          file: Dockerfile.deploy
+    with:
+      file: Dockerfile.deploy
+      output: image
+      push: true
+      meta-images: ghcr.io/tasktix/tasktix-deploy
+      annotations: |
+        org.opencontainers.image.description=A powerful and flexible task-tracking tool for all.
+        org.opencontainers.image.licenses=AGPL-3.0-or-later
+      meta-tags: latest
+      platforms: linux/amd64,linux/arm64
+      fail-fast: true


### PR DESCRIPTION
Uses Docker's [GitHub Builder](<https://docs.docker.com/build/ci/github-actions/github-builder/>) to automatically run builds with a matrix strategy. This should resolve intermittent build issues caused by unexpected opcodes in the arm64 VM. The increased parallelization should also speed up builds.

## Related Issues

- Closes #144 

## Changes

- Switched to GitHub builder
- Standardized on *annotations* instead of *labels* for image metadata - not sure why both were present before

## Testing Coverage

N/A

## Reviewer Notes

I'm not 100% confident that the `annotations:` key will be sufficient for GHCR to link the images to this repository. We'll need to test it out and see...