### PR TITLE
fix: decrement section indices after deleted item

### DIFF
--- a/lib/transformations/list/__tests__/stateToState.test.ts
+++ b/lib/transformations/list/__tests__/stateToState.test.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { listReducer } from '../stateToState';
+import ListItem from '@/lib/model/listItem';
+
+import { listReducer, sectionReducer } from '../stateToState';
 import { ListState } from '../types';
 
 test('Throws an error if an ItemAction is requested for a nonexistent list item', () => {
@@ -46,4 +48,53 @@ test('Throws an error if an ItemAction is requested for a nonexistent list item'
       name: 'new name'
     })
   ).toThrow('Unable to find item with ID nonexistent');
+});
+
+test('Decrements section indices for later items when one is deleted', () => {
+  const list: ListState = {
+    id: 'list-id',
+    name: 'List name',
+    color: 'Amber',
+    hasDueDates: true,
+    hasTimeTracking: true,
+    isAutoOrdered: true,
+    items: new Map([
+      [
+        'item-1',
+        new ListItem('item 1', 'section-id', 'list-id', {
+          sectionIndex: 1,
+          id: 'item-1'
+        })
+      ],
+      [
+        'item-2',
+        new ListItem('item 2', 'section-id', 'list-id', {
+          sectionIndex: 2,
+          id: 'item-2'
+        })
+      ]
+    ]),
+    members: new Map(),
+    sections: new Map([
+      ['section-id', { name: 'Section name', id: 'section-id' }]
+    ]),
+    tags: new Map(),
+    sectionItems: new Map([['section-id', ['item-1', 'item-2']]]),
+    itemAssignees: new Map(),
+    itemTags: new Map(),
+    repoId: null
+  };
+
+  const result = sectionReducer(list, {
+    type: 'DeleteItem',
+    id: 'item-1',
+    sectionId: 'section-id'
+  });
+
+  expect(result.items.size).toBe(1);
+  expect(result.items.has('item-1')).toBe(false);
+  expect(result.items.has('item-2')).toBe(true);
+  expect(result.sectionItems.get('section-id')).toEqual(['item-2']);
+
+  expect(result.items.get('item-2')?.sectionIndex).toBe(1);
 });

--- a/lib/transformations/list/stateToState.ts
+++ b/lib/transformations/list/stateToState.ts
@@ -422,10 +422,20 @@ function sectionReducer<
       if (!sectionItems)
         throw new Error(`Unable to find items for section ${action.sectionId}`);
 
+      const oldIndex = getItem(newState, action.id).sectionIndex;
+
       newState.sectionItems.set(
         action.sectionId,
         sectionItems.filter(item => item === action.id)
       );
+      for (const itemId of sectionItems) {
+        const currentItem = getItem(newState, itemId);
+
+        if (currentItem.sectionIndex > oldIndex) {
+          currentItem.sectionIndex--;
+          newState.items.set(itemId, currentItem);
+        }
+      }
 
       newState.items.delete(action.id);
       break;

--- a/lib/transformations/list/stateToState.ts
+++ b/lib/transformations/list/stateToState.ts
@@ -311,7 +311,7 @@ function tagReducer<T extends { tags: Map<string, Tag> }>(
   return newState;
 }
 
-function sectionReducer<
+export function sectionReducer<
   T extends {
     sections: Map<string, ListSectionState>;
     sectionItems: Map<string, string[]>;
@@ -426,7 +426,7 @@ function sectionReducer<
 
       newState.sectionItems.set(
         action.sectionId,
-        sectionItems.filter(item => item === action.id)
+        sectionItems.filter(item => item !== action.id)
       );
       for (const itemId of sectionItems) {
         const currentItem = getItem(newState, itemId);


### PR DESCRIPTION
Fixes a bug where deleting a list item leaves a gap in section indices where the item used to be, potentially breaking logic for updating indices during reordering.

## Related Issues

- Closes #158 

## Changes

- Fixes bug that may leave gaps in section indices
- Fixes bug causing all items to disappear when deleting one

## Testing Coverage

### Tests added

- Verify that correct items remain after deletion
- Verify section indices are decremented