### PR TITLE
chore: fix VS Code format-on-save race condition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,5 @@
     "editor.defaultFormatter": "Prisma.prisma"
   },
   "files.eol": "\n",
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
 }


### PR DESCRIPTION
Resolves a race condition where Prettier formatting may overlap with ESLint auto fixes (including formatting), causing unexpected file mutations.