### PR TITLE
docs: fix typo referencing container images

### DIFF
--- a/docs/self_hosting.md
+++ b/docs/self_hosting.md
@@ -283,8 +283,8 @@ systemctl --user stop tasktix-web
 
 Then, pull the latest version of the `tasktix-web` and `tasktix-deploy` containers:
 ```sh
-podman pull ghcr.io/tasktix-web:latest
-podman pull ghcr.io/tasktix-deploy:latest
+podman pull ghcr.io/tasktix/tasktix-web:latest
+podman pull ghcr.io/tasktix/tasktix-deploy:latest
 ```
 
 Next, run the `tasktix-deploy` container to update your database's configuration:


### PR DESCRIPTION
Fixes a minor typo in the self-hosting documentation

## Related Issues

- Closes #169 