### PR TITLE
fix(ui): reload on SSE reconnect to avoid unsynced state

### DIFF
--- a/lib/sse/__tests__/client.test.ts
+++ b/lib/sse/__tests__/client.test.ts
@@ -47,6 +47,11 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+afterAll(() => {
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
 describe('subscribe', () => {
   test('Triggers onEvent with JSON-parsed event when SSE message sent', () => {
     const eventHandler = vi.fn();
@@ -106,12 +111,13 @@ describe('subscribe', () => {
     );
   });
 
-  test('Displays toast message when SSE connection is regained', () => {
+  test('Reloads page when SSE connection is regained', () => {
+    const reload = vi.fn();
     const eventHandler = vi.fn();
     const es = vi.fn(MockEventSource) as Mock<typeof EventSource>;
 
+    vi.stubGlobal('location', { reload });
     vi.stubGlobal('EventSource', es);
-    vi.mocked(addToast).mockReturnValue('toast-id');
 
     subscribe(['list-id'], eventHandler);
     es.mock.instances[0].onopen!(new Event('Mock connect event'));
@@ -120,13 +126,7 @@ describe('subscribe', () => {
     es.mock.instances[0].onerror!(new Event('Mock disconnect event'));
     es.mock.instances[0].onopen!(new Event('Mock reconnect event'));
 
-    expect(addToast).toHaveBeenCalledTimes(2);
-    expect(addToast).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Reconnecting for live updates' })
-    );
-    expect(addToast).toHaveBeenLastCalledWith(
-      expect.objectContaining({ title: 'Reconnected' })
-    );
+    expect(reload).toHaveBeenCalled();
   });
 
   test('Cleans up SSE connection when returned function called', () => {

--- a/lib/sse/client.ts
+++ b/lib/sse/client.ts
@@ -51,8 +51,7 @@ export function subscribe(
   const setState = pendingFactory();
 
   es.onopen = () => {
-    if (hasOpened)
-      setState(addToast({ title: 'Reconnected', color: 'success' }));
+    if (hasOpened) location.reload();
     else hasOpened = true;
   };
 


### PR DESCRIPTION
Reloads whenever SSE reconnects (e.g. Internet connection is restored or a tab is woken back up by the browser). This prevents interaction with potentially-stale state on the device that lost SSE connection.

## Related Issues

- Closes #102 

## Testing Coverage

Validates that `location.reload` is called on reconnect.

No automated e2e tests due to Cypress limitations. To test, start a dev server and connect from two devices. Disconnect one from the internet, then reconnect it. It should reload no later than when it receives another SSE event. 

Safari will wait until another event is received to trigger the `onopen` callback, so there's no consistent way to cause a reload without waiting for an event to be received.

## Reviewer Notes

I initially tried a more elegant solution that assigned a counter to every SSE client that incremented with each message sent. If and only if an unexpected message counter was received, the page would be reloaded (since TCP guarantees in-order delivery, so we know it's not just a race condition). This would prevent unnecessary reloads. However, the `EventSource` class is too smart for this (at least on Safari) and, under the hood, opens a second connection before closing the first when reconnecting to SSE. The new connection gets its own counter, resulting in identical behavior to reloading the page every time. As such, I chose the simpler option of just always reloading the page.

In the long run, creating globally-unique counters for events is probably a good idea. This would also provide a way to guarantee that state is still fresh on initial page load (i.e. no changes happened between when it was fetched from the database and when the client initiated an SSE connection).