### PR TITLE
style: improve list item responsiveness

### DIFF
--- a/components/ListItem/ListItem.tsx
+++ b/components/ListItem/ListItem.tsx
@@ -98,6 +98,8 @@ export default function ListItem({
     onItemEvent
   );
 
+  const showAssignees = members.length > 1;
+
   /**
    * Functions for updating the list item timer
    */
@@ -219,7 +221,7 @@ export default function ListItem({
 
   return (
     <div
-      className={`p-4 bg-content1 flex gap-4 items-center justify-between w-full ${reorderControls ? '' : 'border-b-1 border-content3 last:border-b-0'}`}
+      className={`@container p-4 bg-content1 flex gap-4 items-center justify-between w-full ${reorderControls ? '' : 'border-b-1 border-content3 last:border-b-0'}`}
       data-testid={`wrapper-${item.name}`}
     >
       <span className='flex grow gap-4 items-center justify-between w-2/5'>
@@ -247,20 +249,20 @@ export default function ListItem({
         />
 
         <span className='flex gap-4 items-center justify-start grow flex-wrap min-w-0'>
-          <div className='flex min-w-0 grow shrink flex-col w-56 lg:w-60 gap-0 -mt-3 -mb-1'>
+          <div className='flex min-w-0 grow shrink flex-col w-56 @lg:w-60 gap-0 -mt-3 -mb-1'>
             {item.status === 'Completed' ? (
-              <span className='text-sm line-through text-foreground/50 text-nowrap overflow-hidden'>
+              <span className='h-8 flex items-center text-sm line-through text-foreground/50 truncate'>
                 {item.name}
               </span>
             ) : (
               <>
                 <span
-                  className={`text-sm text-foreground truncate md:hidden ${hasDueDates ? '' : 'mt-1'}`}
+                  className={`h-8 flex items-center text-sm text-foreground truncate @md:hidden ${hasDueDates ? '' : 'mt-1'}`}
                 >
                   {item.name}
                 </span>
                 <span
-                  className={`-ml-1 hidden md:flex ${hasDueDates || 'mt-1'}`}
+                  className={`-ml-1 hidden @md:flex ${hasDueDates || 'mt-1'}`}
                 >
                   <ConfirmedTextInput
                     aria-label='Item name'
@@ -310,7 +312,9 @@ export default function ListItem({
           )}
         </span>
       </span>
-      <span className='flex gap-4 items-center justify-between w-3/5'>
+
+      {/* Breakpoint for width should match tags/users being hidden */}
+      <span className='flex gap-4 items-center justify-between w-fit @md:w-3/5'>
         <Priority
           isComplete={item.status === 'Completed'}
           priority={item.priority}
@@ -319,7 +323,7 @@ export default function ListItem({
 
         <Tags
           addNewTag={addNewTag}
-          className='hidden lg:flex'
+          className={`hidden ${showAssignees ? '@3xl:flex' : '@md:flex'}`}
           isComplete={item.status === 'Completed'}
           tagsAdded={item.tags}
           tagsAvailable={tags.values().toArray()}
@@ -327,18 +331,19 @@ export default function ListItem({
           onTagUnlink={itemHandlers.unlinkTag}
         />
 
-        {members.length > 1 ? (
+        {showAssignees && (
           <Users
             assignees={item.assignees}
+            className='hidden @md:flex'
             isComplete={item.status === 'Completed'}
             itemId={item.id}
             members={members}
           />
-        ) : null}
+        )}
 
-        <span className='flex gap-4 items-center justify-end grow md:grow-0 shrink-0 justify-self-end'>
+        <span className='flex gap-4 items-center justify-end grow-0 shrink-0 justify-self-end'>
           {hasTimeTracking ? (
-            <span className='hidden xl:flex gap-4'>
+            <span className='hidden @6xl:flex gap-4'>
               <span
                 className={`flex gap-4 ${item.status === 'Completed' ? 'opacity-50' : ''}`}
               >

--- a/components/ListItem/Tags.tsx
+++ b/components/ListItem/Tags.tsx
@@ -72,12 +72,13 @@ export default function Tags({
       <PopoverTrigger>
         <Button
           aria-label='Update tags'
-          className={`px-4 basis-1/6 grow shrink flex flex-row items-center justify-start overflow-hidden flex-nowrap h-10 shadow-none cursor-pointer bg-transparent ${isComplete ? 'opacity-50 cursor-default' : 'hover:bg-foreground/10 focus:z-10 focus:outline-2 focus:outline-focus focus:outline-offset-2'} ${className}`}
+          className={`basis-1/6 grow shrink justify-start ${className}`}
           isDisabled={isComplete}
           tabIndex={isComplete ? 1 : 0}
+          variant='light'
         >
           <TagsIcon className='shrink-0' />
-          <span className='ml-2 flex flex-row items-center justify-start overflow-hidden flex-nowrap'>
+          <span className='flex flex-row items-center justify-start overflow-hidden flex-nowrap'>
             {displayTags.map(tagDetail => (
               <Chip
                 key={tagDetail.id}

--- a/components/ListItem/Users.tsx
+++ b/components/ListItem/Users.tsx
@@ -95,8 +95,10 @@ export default function Users({
     >
       <PopoverTrigger>
         <Button
-          className={`px-4 basis-1/6 grow shrink flex flex-row items-center justify-start overflow-hidden flex-nowrap h-10 shadow-none cursor-pointer bg-transparent ${isComplete ? 'opacity-50 cursor-default' : 'hover:bg-foreground/10 focus:z-10 focus:outline-2 focus:outline-focus focus:outline-offset-2'} ${className}`}
+          className={`basis-1/6 grow shrink flex justify-start ${className}`}
+          isDisabled={isComplete}
           tabIndex={isComplete ? 1 : 0}
+          variant='light'
         >
           <PeopleFill className='shrink-0' />
           <AvatarGroup

--- a/components/ListItem/__tests__/ListItem.test.tsx
+++ b/components/ListItem/__tests__/ListItem.test.tsx
@@ -238,10 +238,12 @@ it('uses read-only task name text on mobile and keeps inline editing desktop-onl
     </HeroUIProvider>
   );
 
-  expect(getByText('Test item')).toHaveClass('md:hidden');
+  expect(getByText('Test item')).toHaveClass('@md:hidden');
   expect(getByDisplayValue('Test item')).toBeInTheDocument();
   expect(getByDisplayValue('Test item').closest('span')).toHaveClass('hidden');
-  expect(getByDisplayValue('Test item').closest('span')).toHaveClass('md:flex');
+  expect(getByDisplayValue('Test item').closest('span')).toHaveClass(
+    '@md:flex'
+  );
 });
 
 describe('time tracking interactions', () => {

--- a/components/ListSection/AddItem.tsx
+++ b/components/ListSection/AddItem.tsx
@@ -191,7 +191,7 @@ export default function AddItem({
 
   return (
     <span>
-      <span className='hidden xl:flex justify-between items-center overflow-y-visible'>
+      <span className='hidden @2xl:flex justify-between items-center overflow-y-visible'>
         <span className='overflow-x-clip'>
           <form
             className={`flex gap-4 pr-4 transition-transform${isSliderOpen ? '' : ' translate-x-full'}`}
@@ -300,7 +300,7 @@ export default function AddItem({
           />
         </Button>
       </span>
-      <span className='flex xl:hidden'>
+      <span className='flex @2xl:hidden'>
         <Button
           isIconOnly
           color='primary'

--- a/components/ListSection/ListSection.tsx
+++ b/components/ListSection/ListSection.tsx
@@ -125,13 +125,13 @@ export default function ListSection({
 
   return (
     <div
-      className={`rounded-md overflow-hidden border-2 border-content3 box-border shrink-0 shadow-lg shadow-content2 ${isKanban ? 'w-100' : 'w-full'}`}
+      className={`@container rounded-md overflow-hidden border-2 border-content3 box-border shrink-0 shadow-lg shadow-content2 ${isKanban ? 'w-100' : 'w-full'}`}
       data-testid={
         isKanban ? 'kanban-section-format' : 'vertical-section-format'
       }
     >
       <div className='bg-content3 font-bold p-4 h-16 flex items-center justify-between'>
-        <span className='min-w-fit shrink-0 flex'>
+        <span className='min-w-0 shrink flex'>
           <Button
             isIconOnly
             aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}


### PR DESCRIPTION
Improves mobile friendliness by hiding assignees on small screens and ensuring section settings remain visible. Also applies miscellaneous minor style fixes

## Changes

- Fixed list members to hide on small screens
- Fixed section settings getting pushed out of view on very small screens and kanban mode
- Updated responsive changes to also work on kanban mode (via `@container` and `@md:`/`@xl:`/etc. Tailwind classes)
- Updated plaintext item names to more closely match the spacing of version that allows input
- Removed some button styling that duplicated `variant='light'`

## Testing Coverage

No logic changes applied. Used browser responsiveness tools to manually validate appropriate behavior.