### PR TITLE
fix: stop tasktix-deploy container after migration when using as oneshot

### DIFF
--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -34,6 +34,7 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL}
       DISABLE_AUTH_RATE_LIMIT: ${DISABLE_AUTH_RATE_LIMIT}
       DISABLE_PASSWORD_STRENGTH_CHECK: true # Disabled for seed scripts (n.b. this is only the deploy container)
+      KEEP_ALIVE: true
     healthcheck:
       test: ['CMD', 'test', '-f', '/tmp/prisma-ready']
       interval: 2s

--- a/docs/self_hosting.md
+++ b/docs/self_hosting.md
@@ -130,11 +130,6 @@ You'll also need to run the following command to set up your database:
 podman run --rm --detach --pod tasktix --secret "TASKTIX_DATABASE_URL,type=env,target=DATABASE_URL" ghcr.io/tasktix/tasktix-deploy:latest
 ```
 
-> [!NOTE]
-> The deploy container currently does not respect `SIGTERM` or `SIGQUIT`. We recommend
-  running the above command with the `--detach` flag, giving it ~10 seconds to run, then
-  killing it with `podman stop`.
-
 ### Configuration
 
 As the administrator for your Tasktix instance, you can customize some of Tasktix's

--- a/scripts/test_service_entry.sh
+++ b/scripts/test_service_entry.sh
@@ -7,4 +7,6 @@ npm run prisma:deploy
 touch /tmp/prisma-ready
 
 # Keep container alive for running prisma:reset later
-sleep infinity
+if [ -n "${KEEP_ALIVE+x}" ]; then
+  sleep infinity
+fi


### PR DESCRIPTION
When running `tasktix-deploy` as a oneshot container (i.e. to migrate the production database) and not as a persistent container (i.e. to reset & reseed the database during e2e tests), the container should exit after migrations are applied. This ensures that happens.

## Related Issues

- Closes #116 