### PR TITLE
chore: fix build failing due to insufficient permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       output: image
       push: true


### PR DESCRIPTION
Gives the new Docker GitHub-Builder workflow permission to sign its builds.