### PR TITLE
chore: fix build failing due to insufficient permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     secrets:
       registry-auths: |
         - registry: ghcr.io


### PR DESCRIPTION
Fixes the `deploy` image build process, too